### PR TITLE
"Qt Quick" when not referring to the import module 

### DIFF
--- a/ch01/index.rst
+++ b/ch01/index.rst
@@ -22,7 +22,7 @@ Preface
 
 Qt 4 has evolved since 2005 and provided a solid ground for thousands of applications and even full desktop and mobile systems. The usage patterns computer users changed in the recent years. From stationary PCs towards portable notebook and nowadays mobile computers. The classical desktop is more and more replaced with mobile touch-based always connected screens. With it the desktop UX paradigms also changes. Where as in the past Windows UI has dominated the world we spend more time nowadays on other screens with another UI language.
 
-Qt 4 was designed to satisfy the desktop world to have a coherent set of UI widgets available on all major platforms. The challenge for Qt users has changed today and it lies more to provide a touch-based user interface for a customer driven user interface and to enable modern user interface on all major desktop and mobile systems. Qt 4.7 started to introduce the QtQuick technology which allows users to create a set of user interface components from simple elements to achieve a complete new UI, driven by customer demands.
+Qt 4 was designed to satisfy the desktop world to have a coherent set of UI widgets available on all major platforms. The challenge for Qt users has changed today and it lies more to provide a touch-based user interface for a customer driven user interface and to enable modern user interface on all major desktop and mobile systems. Qt 4.7 started to introduce the Qt Quick technology which allows users to create a set of user interface components from simple elements to achieve a complete new UI, driven by customer demands.
 
 Qt5 Focus
 ---------
@@ -55,7 +55,7 @@ Qt Quick is the umbrella term for the user interface technology used in Qt5. Qt 
 .. image:: assets/qt5_overview.png
 
 
-Similar to HTML, QML is a markup language. It is composed of tags called elements in QtQuick enclosed in curly brackets ``Item {}``. It was designed from the ground up for the creation of user interfaces, speed and easier reading for developers. The user interface can be enhanced using JavaScript code. Qt Quick is easily extend able with your own native functionality using Qt C++. In short the declarative UI is called the front-end and the native parts are called the back-end. This allows you to separate the computing intensive and native operation of your application from the user interface part.
+Similar to HTML, QML is a markup language. It is composed of tags called elements in Qt Quick enclosed in curly brackets ``Item {}``. It was designed from the ground up for the creation of user interfaces, speed and easier reading for developers. The user interface can be enhanced using JavaScript code. Qt Quick is easily extend able with your own native functionality using Qt C++. In short the declarative UI is called the front-end and the native parts are called the back-end. This allows you to separate the computing intensive and native operation of your application from the user interface part.
 
 In a typical project the front-end is developed in QML/JavaScript and the back-end code, which interfaces with the system and does the heavy lifting is developed using Qt C++. This allows a natural split between the more design oriented developers and the functional developers. Typically the back-end is tested using Qt own unit testing framework and exported for the front-end developers to be used.
 
@@ -63,7 +63,7 @@ In a typical project the front-end is developed in QML/JavaScript and the back-e
 Digesting an User Interface
 ---------------------------
 
-Let's create a simple user interface using QtQuick, which showcases some aspects of the QML language. At the end we will have a paper windmill with rotating blades.
+Let's create a simple user interface using Qt Quick, which showcases some aspects of the QML language. At the end we will have a paper windmill with rotating blades.
 
 We start with an empty document called ``main.qml``. All QML files will have the ending ``.qml``. As a markup language (like HTML) a QML document needs to have one and only one root element, which in our case is the ``Image`` element with a width and height based on the background image geometry:
 

--- a/ch02/index.rst
+++ b/ch02/index.rst
@@ -110,7 +110,7 @@ Qt 5 seems to be working and we are ready to continue.
 
     After a successful compilation and 2 cups of coffee, Qt 5 will be available in the ``qtbase`` folder. Any beverage will suffice, however, we suggest coffee for best results.
 
-    If you want to test your compilation, simply start ``qtbase/bin/qmlscene`` and select a QtQuick example to run it ...or follow just us into the next chapter.
+    If you want to test your compilation, simply start ``qtbase/bin/qmlscene`` and select a Qt Quick example to run it ...or follow just us into the next chapter.
 
 
     To test your installation, we will create a small hello world application. Please create a simple ``example.qml`` file using your favorite text editor and paste the following content inside:

--- a/ch03/index.rst
+++ b/ch03/index.rst
@@ -6,7 +6,7 @@ Qt Creator IDE
 
 .. issues:: ch03
 
-Qt Creator is the default integrated development environment for Qt. It's written from Qt developers for Qt developers. The IDE is can be used on all major desktop platforms, e.g. Windows/Mac/Linux. We have already seen customers using Qt Creator on an embedded device. Qt Creator has a lean efficient user interface and it shines really in making the developer productive. Qt Creator can be used to run your QtQuick user interface but also to compile c++ code and this fr your host system or using a cross-complier for your device system.
+Qt Creator is the default integrated development environment for Qt. It's written from Qt developers for Qt developers. The IDE is can be used on all major desktop platforms, e.g. Windows/Mac/Linux. We have already seen customers using Qt Creator on an embedded device. Qt Creator has a lean efficient user interface and it shines really in making the developer productive. Qt Creator can be used to run your Qt Quick user interface but also to compile c++ code and this fr your host system or using a cross-complier for your device system.
 
 .. image:: assets/qtcreator-screenshots.png
 
@@ -61,15 +61,15 @@ Managing Projects
 
 .. issues:: ch03
 
-Qt Creator manages your source code in projects. You can create a new project by using :menuselection:`File --> New File or Project`. When you create a project you have many choices of application templates. Qt Creator is capable of creating desktop, mobile applications. Application which use Widgets or QtQuick or QtQuick and controls or even bare-bone projects. Also project for HTML5 and python are supported. For a beginner it is difficult to choose, so we pick three project types for you.
+Qt Creator manages your source code in projects. You can create a new project by using :menuselection:`File --> New File or Project`. When you create a project you have many choices of application templates. Qt Creator is capable of creating desktop, mobile applications. Application which use Widgets or Qt Quick or Qt Quick and controls or even bare-bone projects. Also project for HTML5 and python are supported. For a beginner it is difficult to choose, so we pick three project types for you.
 
-* **Applications / QtQuick 2.0 UI**: This will create a QML/JS only project for you, without any C++ code. Take this if you want to sketch a new user interface or plan to create a modern UI application where the native parts are delivered by plug-ins.
-* **Libraries / Qt Quick 2.0 Extension Plug-in**: Use this wizard to create a stub for a plug-in for your QtQuick UI. A plug-in is used to extend QtQuick with native elements.
+* **Applications / Qt Quick 2.0 UI**: This will create a QML/JS only project for you, without any C++ code. Take this if you want to sketch a new user interface or plan to create a modern UI application where the native parts are delivered by plug-ins.
+* **Libraries / Qt Quick 2.0 Extension Plug-in**: Use this wizard to create a stub for a plug-in for your Qt Quick UI. A plug-in is used to extend Qt Quick with native elements.
 * **Other Project / Empty Qt Project**: A bare-bone empty project. Take this if you want to code your application with c++ from scratch. Be aware you need to know what you are doing here.
 
 .. note::
 
-	During the first parts of the book we will mainly use the QtQuick 2.0 UI project type. Later to describe some c++ aspects we will use the Empty-Qt-Project type or something similar. For extending QtQuick with our own native plug-ins we will use the *Qt Quick 2.0 Extension Plug-in* wizard type.
+	During the first parts of the book we will mainly use the Qt Quick 2.0 UI project type. Later to describe some c++ aspects we will use the Empty-Qt-Project type or something similar. For extending Qt Quick with our own native plug-ins we will use the *Qt Quick 2.0 Extension Plug-in* wizard type.
 
 
 

--- a/ch04/index.rst
+++ b/ch04/index.rst
@@ -48,7 +48,7 @@ Let's start with a simple example of a QML file to explain the different syntax.
 
 .. hint::
 
-    You can run the example using the QtQuick runtime from the command line from your OS like this::
+    You can run the example using the Qt Quick runtime from the command line from your OS like this::
 
         $ $QTDIR/bin/qmlscene rectangle.qml
 
@@ -285,7 +285,7 @@ To interact with these elements you often will use a ``MouseArea``. Its a rectan
 
 .. note::
 
-    This is an important aspect of QtQuick, the input handling is separated from the visual presentation. By this it allows you to show the user an interface element, but the interaction area can be larger.
+    This is an important aspect of Qt Quick, the input handling is separated from the visual presentation. By this it allows you to show the user an interface element, but the interaction area can be larger.
 
 Components
 ==========
@@ -471,7 +471,7 @@ An element often used with positioners is the ``Repeater``. It works like a for-
     :start-after: M1>>
     :end-before: <<M1
 
-In this repeater example, we use some new magic. We define our own color property, which we use as an array of colors. The repeater creates a series of rectangles (16, as defined by the model). For each loop he creates the rectangle as defined as child of the repeater. In the rectangle we chose the color by using JS math functions ``Math.floor(Math.random()*3)``. This gives us a random number in the range from 0..2, which we use to select the color from our color array. As noted earlier JavaScript is a core part of QtQuick, as such the standard libraries are available for us.
+In this repeater example, we use some new magic. We define our own color property, which we use as an array of colors. The repeater creates a series of rectangles (16, as defined by the model). For each loop he creates the rectangle as defined as child of the repeater. In the rectangle we chose the color by using JS math functions ``Math.floor(Math.random()*3)``. This gives us a random number in the range from 0..2, which we use to select the color from our color array. As noted earlier JavaScript is a core part of Qt Quick, as such the standard libraries are available for us.
 
 A repeater injects the ``index`` property into the repeater. It contains the current loop-index. (0,1,..15). We can use this to make our own decisions based on the index, or in our case to visualize the current index with the ``Text`` element.
 

--- a/ch05/index.rst
+++ b/ch05/index.rst
@@ -22,7 +22,7 @@ Animations
 
 .. issues:: ch05
 
-Animations are applied to property changes. An animation defines the interpolation curve when for property value changes to create smooth transitions from one value to another. An animation is defined by a series of target properties to be animated, an easing curve for the interpolation curve and in the most cases a duration, which defines the time for the property change. All animations in QtQuick are controlled by the same timer, and are therefore synchronized. This improves the performance and visual quality of animations.
+Animations are applied to property changes. An animation defines the interpolation curve when for property value changes to create smooth transitions from one value to another. An animation is defined by a series of target properties to be animated, an easing curve for the interpolation curve and in the most cases a duration, which defines the time for the property change. All animations in Qt Quick are controlled by the same timer, and are therefore synchronized. This improves the performance and visual quality of animations.
 
 .. note::
 
@@ -54,7 +54,7 @@ There are several types of animation elements, each optimized for a specific use
 * ``RotationAnimation`` - Animates changes in rotation values
 
 
-Besides these basic and widely used animation elements, QtQuick provides also more specialized animations for specific use cases:
+Besides these basic and widely used animation elements, Qt Quick provides also more specialized animations for specific use cases:
 
 * ``PauseAnimation`` - Provides a pause for an animation
 * ``SequentialAnimation`` - Allows animations to be run sequentially
@@ -66,7 +66,7 @@ Besides these basic and widely used animation elements, QtQuick provides also mo
 * ``PathAnimation`` - Animates an item along a path
 * ``Vector3dAnimation`` - Animates changes in QVector3d values
 
-We will learn later how to create a sequence of animations. While working on more complex animations there comes up the need to change a property or to run a script during an an ongoing animation. For this QtQuick offers the action elements, which can be used everywhere where the other animation elements can be used:
+We will learn later how to create a sequence of animations. While working on more complex animations there comes up the need to change a property or to run a script during an an ongoing animation. For this Qt Quick offers the action elements, which can be used everywhere where the other animation elements can be used:
 
 * ``PropertyAction`` - Specifies immediate property changes during animation
 * ``ScriptAction`` - Defines scripts to be run during an animation

--- a/ch06/index.rst
+++ b/ch06/index.rst
@@ -16,7 +16,7 @@ Model-View-Delegate
 
 
 
-In QtQuick, data is separated from the presentation through a model-view separation. For each view, the visualization of each data element is separated into a delegate. QtQuick comes with a set of predefined models and views. To utilize the system, one must understand these classes and know how to create appropriate delegates to get the right look and feel.
+In Qt Quick, data is separated from the presentation through a model-view separation. For each view, the visualization of each data element is separated into a delegate. Qt Quick comes with a set of predefined models and views. To utilize the system, one must understand these classes and know how to create appropriate delegates to get the right look and feel.
 
 
 Concept
@@ -88,7 +88,7 @@ Dynamic Views
 
 .. issues:: ch06
 
-Repeaters work well for limited and static sets of data, but in the real world, models are commonly more complex -- and larger. Here, a smarter solution is needed. For this, QtQuick provides the ``ListView`` and ``GridView`` elements. These are both based on a ``Flickable`` area, so the user can move around in a larger data set. At the same time, they limit the number of concurrently instantiated delegates. For a large model, that means fewer elements in the scene at once.
+Repeaters work well for limited and static sets of data, but in the real world, models are commonly more complex -- and larger. Here, a smarter solution is needed. For this, Qt Quick provides the ``ListView`` and ``GridView`` elements. These are both based on a ``Flickable`` area, so the user can move around in a larger data set. At the same time, they limit the number of concurrently instantiated delegates. For a large model, that means fewer elements in the scene at once.
 
 .. image:: assets/automatic/listview-basic.png
 .. image:: assets/automatic/gridview-basic.png
@@ -103,7 +103,7 @@ The ``ListView`` is similar to the ``Repeater`` element. It uses a ``model``, in
 
 .. image:: assets/automatic/listview-basic.png
 
-If the model contains more data than can fit onto the screen, the ``ListView`` only shows part of the list. However, as a consequence of the default behavior of QtQuick, the list view does not limit the screen area within which the delegates are shown. This means that delegates may be visible outside the list view, and that the dynamic creation and destruction of delegates outside the list view is visible to the user. To prevent this, clipping must be activated on the ``ListView`` element by setting the ``clip`` property to ``true``. The illustration below shows the result of this, compared to when the ``clip`` property is left as ``false``.
+If the model contains more data than can fit onto the screen, the ``ListView`` only shows part of the list. However, as a consequence of the default behavior of Qt Quick, the list view does not limit the screen area within which the delegates are shown. This means that delegates may be visible outside the list view, and that the dynamic creation and destruction of delegates outside the list view is visible to the user. To prevent this, clipping must be activated on the ``ListView`` element by setting the ``clip`` property to ``true``. The illustration below shows the result of this, compared to when the ``clip`` property is left as ``false``.
 
 .. image:: assets/automatic/listview-clip.png
 
@@ -273,7 +273,7 @@ The PathView
 
 .. issues:: ch06
 
-The ``PathView`` element is the most powerful, but also the most complex, view provided in QtQuick. It makes it possible to create a view where the items are laid out along an arbitrary path. Along the same path, attributes such as scale, opacity and more can be controlled in detail.
+The ``PathView`` element is the most powerful, but also the most complex, view provided in Qt Quick. It makes it possible to create a view where the items are laid out along an arbitrary path. Along the same path, attributes such as scale, opacity and more can be controlled in detail.
 
 When using the ``PathView``, you have to define a delegate and a path. In addition to this, the ``PathView`` itself can be customized through a range of properties. The most common being ``pathItemCount``, controlling the number of visible items at once, and the highlight range control properties ``preferredHighlightBegin``, ``preferredHighlightEnd`` and ``highlightRangeMode``, controlling where along the path the current item is to be shown.
 

--- a/ch07/index.rst
+++ b/ch07/index.rst
@@ -18,7 +18,7 @@ Canvas Element
 
 .. image:: assets/glowlines.png
 
-Early on when QML was introduced in Qt4 there where some discussions about if QtQuick needs an ellipse. The problem with the ellipse is that others can argue other shapes need also be supported. So there is no ellipse in Qt Quick only rectangular shapes. If you needed one in Qt4 you would need to use an image or write your own C++ ellipse element.
+Early on when QML was introduced in Qt4 there where some discussions about if Qt Quick needs an ellipse. The problem with the ellipse is that others can argue other shapes need also be supported. So there is no ellipse in Qt Quick only rectangular shapes. If you needed one in Qt4 you would need to use an image or write your own C++ ellipse element.
 
 To allow scripted drawings Qt5 introduces the canvas element. The canvas elements provides a resolution-dependent bitmap canvas, which can be used for graphics, games or to paint other visual images on the fly using JavaScript. The canvas element is based on the HTML5 canvas element.
 

--- a/ch10/index.rst
+++ b/ch10/index.rst
@@ -8,7 +8,7 @@ Multimedia
 
 The multimedia elements in the QtMultimedia makes it possible to playback and record media such as sound, video or pictures. Decoding and encoding is handled through platform specific backends. For instance, the popular gstreamer framework is used on Linux, while DirectShow is used on Windows and QuickTime on OS X.
 
-The multimedia elements are not a part of the QtQuick core API. Instead, they are provided through a separate API made available by importing QtMultimedia 5.0 as shown below::
+The multimedia elements are not a part of the Qt Quick core API. Instead, they are provided through a separate API made available by importing QtMultimedia 5.0 as shown below::
 
     import QtMultimedia 5.0
 

--- a/ch11/index.rst
+++ b/ch11/index.rst
@@ -8,7 +8,7 @@ Networking
 
 Qt5 comes with a rich set of networking classes on the C++ side. There are for example high level classes on the http protocol layer in a request-reply fashion such as ``QNetworkRequest``, ``QNetworkReply`` and ``QNetworkAccessManager``. But also lower levels classes on the TCP/IP or UDP protocol layer such as ``QTcpSocket``, ``QTcpServer`` and ``QUdpSocket``. Additional classes exists to manage proxies, network cache and also the systems network configuration.
 
-This chapter will not be about C++ networking, this chapter is about QtQuick and networking. So how can I connect my QML/JS user interface directly with a network service or how can I serve my user interface via a network service. There are good books and references out there to cover network programming with Qt/C++. Then it is just a manner to read the chapter about C++ integration to come up with an integration layer to feed your data into the QtQuick world.
+This chapter will not be about C++ networking, this chapter is about Qt Quick and networking. So how can I connect my QML/JS user interface directly with a network service or how can I serve my user interface via a network service. There are good books and references out there to cover network programming with Qt/C++. Then it is just a manner to read the chapter about C++ integration to come up with an integration layer to feed your data into the Qt Quick world.
 
 Serving UI via HTTP
 ===================
@@ -154,7 +154,7 @@ HTTP Requests
 
 .. issues:: ch11
 
-A http request is in Qt typical done using ``QNetworkRequest`` and ``QNetworkReply`` from the c++ site and then the response would be pushed using the Qt/C++ integration into the QML space. So we try to push the envelope here a little bit to use the current tools QtQuick gives us to communicate with a network endpoint. For this we use a helper object to make http request, response cycle. It comes in the form of the java script ``XMLHttpRequest`` object.
+A http request is in Qt typical done using ``QNetworkRequest`` and ``QNetworkReply`` from the c++ site and then the response would be pushed using the Qt/C++ integration into the QML space. So we try to push the envelope here a little bit to use the current tools Qt Quick gives us to communicate with a network endpoint. For this we use a helper object to make http request, response cycle. It comes in the form of the java script ``XMLHttpRequest`` object.
 
 The ``XMLHttpRequest`` object allows the user to register a response handle function and a url. A request can be send using one of the http verbs (get, post, put, delete, ...) to make the request. When the response arrive the handle function is called. The handle function is called several times. Every-time the request state has changed (for example headers have arrived or request is done).
 
@@ -279,7 +279,7 @@ Is it also possible to load local (XML/JSON) files using the XMLHttpRequest. For
 
 	xhr.open("GET", "colors.json");
 
-We use this to read a color table and display it as a grid. It is not possible to modify the file from the QtQuick side. To store data back to the source we would need a small REST based HTTP server or a native QtQuick extension for file access.
+We use this to read a color table and display it as a grid. It is not possible to modify the file from the Qt Quick side. To store data back to the source we would need a small REST based HTTP server or a native Qt Quick extension for file access.
 
 .. literalinclude:: src/localfiles/localfiles.qml
 

--- a/ch12/index.rst
+++ b/ch12/index.rst
@@ -6,9 +6,9 @@ Storage
 
 .. sectionauthor:: `jryannel <https://bitbucket.org/jryannel>`_
 
-This chapter will cover storing data using QtQuick in Qt5. QtQuick offers only limited ways of storing local data. In this sense it acts more like a browser. In many projects storing data is handled by the C++ backend and the required functionality is exported to the QtQuick frontend side. QtQuick does not provide you with access to the host file system to read and write files as you are used from the Qt C++ side. So it would be task of the backend engineer to write such a plugin or maybe use a network channel to communicate with a local server, which provides these capabilities.
+This chapter will cover storing data using Qt Quick in Qt5. Qt Quick offers only limited ways of storing local data. In this sense it acts more like a browser. In many projects storing data is handled by the C++ backend and the required functionality is exported to the Qt Quick frontend side. Qt Quick does not provide you with access to the host file system to read and write files as you are used from the Qt C++ side. So it would be task of the backend engineer to write such a plugin or maybe use a network channel to communicate with a local server, which provides these capabilities.
 
-Every application need to store smaller and larger information persistently. This can be locally on the file system or remote on a server. Some information will be structured and simple (e.g. settings), some will be large and complicated for example documentation files and some will be large and structured and will require some sort of database connection. Here we will mainly cover the built in capabilities of QtQuick to store data as also the networked ways.
+Every application need to store smaller and larger information persistently. This can be locally on the file system or remote on a server. Some information will be structured and simple (e.g. settings), some will be large and complicated for example documentation files and some will be large and structured and will require some sort of database connection. Here we will mainly cover the built in capabilities of Qt Quick to store data as also the networked ways.
 
 .. hint::
 


### PR DESCRIPTION
Ref: https://github.com/jryannel/qt5-cadaques/issues/181

When not referring directly to the import module, "Qt Quick" is used instead  of "QtQuick". This seems to be inline with Qt Creator, where creating a new project refers to "Qt Quick".