### PR TITLE
Add python3 support

### DIFF
--- a/_extensions/issues.py
+++ b/_extensions/issues.py
@@ -1,6 +1,10 @@
 from docutils import nodes
 from sphinx.util.compat import Directive
-import urllib
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
 
 class issues(nodes.General, nodes.Element):
     pass
@@ -26,7 +30,7 @@ def html_visit_issues_node(self, node):
         aname = node.parent['ids'][0]
     target = self.builder.get_target_uri(self.builder.current_docname)
     back_link = 'back-link: %s#%s'%(target, aname)
-    query = urllib.urlencode({'labels': label, 'body':back_link})
+    query = urlencode({'labels': label, 'body':back_link})
     create_url = '%s/new?%s'%(base_url, query)
     view_url = '%s?labels=%s&page=1&state=open'%(base_url, label)
     self.body.append('<div class="admonition issues">')

--- a/_extensions/youtube.py
+++ b/_extensions/youtube.py
@@ -19,7 +19,7 @@ def get_size(d, key):
     return int(m.group(1)), m.group(2) or "px"
 
 def css(d):
-    return "; ".join(sorted("%s: %s" % kv for kv in d.iteritems()))
+    return "; ".join(sorted("%s: %s" % kv for kv in d.items()))
 
 class youtube(nodes.General, nodes.Element): pass
 


### PR DESCRIPTION
There are differencies between python3 and python2 as regard two things I have spotted while trying to compile the QML book:

1. The urlencode function from the urllib module is now present in a submodule urllib.parse in Python 3
2. The `iteritems()` dict method is irrelevant in Python3 since the `items()` dict method returns a generator instead of building an in-memory list as it does in Python 2. It could be some kind of caveat if the script is runing in Python 2, but I do not think one could get some memory issue for now.

What do you guys think?