### PR TITLE
fix typo in chapter 16: "Is it also" -> "It is also"

### DIFF
--- a/en/ch16/index.rst
+++ b/en/ch16/index.rst
@@ -38,7 +38,7 @@ In the example the ``QGuiApplication`` encapsulates all that is related to the a
 
 In the qml file we declare our dependencies here it is ``QtQuick`` and ``QtQuick.Window``. These declaration will trigger a lookup for these modules in the import paths and on success will load the required plugins by the engine. The newly loaded types will then be made available to the qml file controlled by a qmldir.
 
-Is it also possible to shortcut the plugin creation by adding our types directly to the engine. Here we assume we have a ``CurrentTime`` ``QObject`` based class.
+It is also possible to shortcut the plugin creation by adding our types directly to the engine. Here we assume we have a ``CurrentTime`` ``QObject`` based class.
 
 .. code-block:: cpp
 


### PR DESCRIPTION
fixes issue #119

> back-link: en/ch16/index.html#understanding-the-qml-run-time
> 
> "Is it also" -> "It is also"
