### PR TITLE
fix typo 'putImageData(imagedata,, dx, dy) -> putImageData(imagedata, dx, dy)

### DIFF
--- a/en/ch07/index.rst
+++ b/en/ch07/index.rst
@@ -202,7 +202,7 @@ Pixel Buffers
 
 .. issues:: ch07
 
-When working with the canvas you are able to retrieve pixel data from the canvas to read or manipulate the pixels of your canvas. To read the image data use ``createImageData(sw,sh)`` or ``getImageData(sx,sy,sw,sh)``. Both functions return an ``ImageData`` object with a ``width``, ``height`` and a ``data`` variable. The data variable contains a one-dimensional array of the pixel data retrieved in the *RGBA* format, where each value varies in the range of 0 to 255. To set pixels on the canvas you can use the ``putImageData(imagedata,, dx, dy)`` function.
+When working with the canvas you are able to retrieve pixel data from the canvas to read or manipulate the pixels of your canvas. To read the image data use ``createImageData(sw,sh)`` or ``getImageData(sx,sy,sw,sh)``. Both functions return an ``ImageData`` object with a ``width``, ``height`` and a ``data`` variable. The data variable contains a one-dimensional array of the pixel data retrieved in the *RGBA* format, where each value varies in the range of 0 to 255. To set pixels on the canvas you can use the ``putImageData(imagedata, dx, dy)`` function.
 
 Another way to retrieve the content of the canvas is to store the data into an image. This can be achieved with the ``Canvas`` functions ``save(path)`` or ``toDataURL(mimeType)``, where the later function returns an image url, which can be used to be loaded by an ``Image`` element.
 


### PR DESCRIPTION
fixes issue #118:

> back-link: en/ch07/index.html#pixel-buffers
> 
> I think this function call: putImageData(imagedata,, dx, dy) should be putImageData(imagedata, dx, dy)
