### PR TITLE
Update qtcreator.rst

### DIFF
--- a/docs/ch03-qtcreator/qtcreator.rst
+++ b/docs/ch03-qtcreator/qtcreator.rst
@@ -110,7 +110,7 @@ Qt Creator comes with C++ and QML debugging support.
 
 .. note::
 
-    Hmm, I just realized I have not used debugging a lot. I hope this is a good sign. Need to ask someone to help me out here. In the meantime have a look at the `Qt Creator documentation <http://http://doc.qt.io/qtcreator/index.html>`_.
+    Hmm, I just realized I have not used debugging a lot. I hope this is a good sign. Need to ask someone to help me out here. In the meantime have a look at the `Qt Creator documentation <http://doc.qt.io/qtcreator/index.html>`_.
 
 Shortcuts
 =========


### PR DESCRIPTION
Link to Qt Creator documentation is unavailable: `http://http://doc.qt.io/qtcreator/index.html`