### PR TITLE
Fix json load for Python2 and Python3

### DIFF
--- a/docs/ch12-networking/networking.rst
+++ b/docs/ch12-networking/networking.rst
@@ -328,7 +328,13 @@ A simple web-service in Flask can be written in one file. We start with an empty
     from flask import Flask, jsonify, request
     import json
 
-    colors = json.load(file('colors.json', 'r'))
+    import sys
+    if sys.version_info >= (3, 0):
+    #Python 3 and later
+       colors = json.load(open('colors.json', 'r'))
+    else:
+    #Python 2
+       colors = json.load(file('colors.json', 'r'))
 
     app = Flask(__name__)
 

--- a/docs/ch12-networking/src/restservice/server.py
+++ b/docs/ch12-networking/src/restservice/server.py
@@ -3,7 +3,13 @@
 from flask import Flask, jsonify, request
 import json
 
-colors = json.load(file('colors.json', 'r'))
+import sys
+if sys.version_info >= (3, 0):
+#Python 3 and later
+    colors = json.load(open('colors.json', 'r'))
+else:
+#Python 2
+    colors = json.load(file('colors.json', 'r'))
 
 app = Flask(__name__)
 
@@ -50,4 +56,3 @@ def delete_color(name):
     
 if __name__ == '__main__':
     app.run(debug = True)
-    


### PR DESCRIPTION
Python version verification added to code.

This pull request fix, when trying to run the current code on Python3 we get an error:
```
$ python server.py 
Traceback (most recent call last):
  File "server.py", line 6, in <module>
    colors = json.load(file('colors.json', 'r'))
NameError: name 'file' is not defined
```