### PR TITLE
Fixes stray "the" in meetqt.rst

### DIFF
--- a/docs/ch01-meetqt/meetqt.rst
+++ b/docs/ch01-meetqt/meetqt.rst
@@ -310,7 +310,7 @@ From the `Qt Project wiki <http://wiki.qt.io/>`_:
 
     "The Qt Project is a meritocratic consensus-based community interested in Qt. Anyone who shares that interest can join the community, participate in its decision-making processes, and contribute to Qt’s development."
 
-The Qt Project is an organization which develops the open-source part of the Qt further. It forms the base for other users to contribute. The biggest contributor is The Qt Company, which holds also the commercial rights to Qt.
+The Qt Project is an organization which develops the open-source part of Qt further. It forms the base for other users to contribute. The biggest contributor is The Qt Company, which holds also the commercial rights to Qt.
 
 Qt has an open-source aspect and a commercial aspect for companies. The commercial aspect is for companies which can not or will not comply with the open-source licenses. Without the commercial aspect, these companies would not be able to use Qt and it would not allow The Qt Company to contribute so much code to the Qt Project.
 


### PR DESCRIPTION
Alternatively, maybe the "the" could be kept, if an additional word was added after "Qt", e.g. "framework".