### PR TITLE
c08-felgo: Fix onTextInputFinished (missing curly brace)

### DIFF
--- a/docs/ch08-felgo/src/snippets/native-dialog.qml
+++ b/docs/ch08-felgo/src/snippets/native-dialog.qml
@@ -13,7 +13,8 @@ App {
     Connections {
       target: nativeUtils
       onTextInputFinished: function (accepted, result) {
-      console.log("Here's the result " + result)
+        console.log("Here's the result " + result)
+      }
     }
   }
 }


### PR DESCRIPTION
This pull request corrects a minor issue in a qmlbook example.

In the example a closing curly brace for `onTextInputFinished: function (accepted, result) {`  is missing.

-------

![grafik](https://user-images.githubusercontent.com/6735650/127492366-b60a8b60-8431-4a0e-979b-265e96718abb.png)
